### PR TITLE
Indexes the product repository.

### DIFF
--- a/org.fipro.headless.product/headless.bndrun
+++ b/org.fipro.headless.product/headless.bndrun
@@ -1,3 +1,7 @@
+index: target/index.xml;name="org.fibro.headless.product"
+
+-standalone: ${index}
+
 -runee: JavaSE-1.8
 -runfw: org.eclipse.osgi
 -runsystemcapabilities: ${native_capability}

--- a/org.fipro.headless.product/headless_console.bndrun
+++ b/org.fipro.headless.product/headless_console.bndrun
@@ -1,3 +1,7 @@
+index: target/index.xml;name="org.fibro.headless.product"
+
+-standalone: ${index}
+
 -runee: JavaSE-1.8
 -runfw: org.eclipse.osgi
 -runsystemcapabilities: ${native_capability}

--- a/org.fipro.headless.product/pom.xml
+++ b/org.fipro.headless.product/pom.xml
@@ -46,6 +46,24 @@
 			</plugin>
 			<plugin>
 				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-indexer-maven-plugin</artifactId>
+				<version>4.3.1</version>
+				<configuration>
+					<!-- <outputFile>${project.build.directory}/custom.xml</outputFile> -->
+					<inputDir>${project.build.directory}/repository/plugins/</inputDir>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<id>index</id>
+						<goals>
+							<goal>local-index</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>			
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
 				<artifactId>bnd-export-maven-plugin</artifactId>
 				<version>4.3.1</version>
 				<configuration>
@@ -55,7 +73,7 @@
 						<bndrun>headless_console.bndrun</bndrun>
 					</bndruns>
 					<bundles>
-						<include>target/repository/plugins/*</include>
+						<include>${project.build.directory}/repository/plugins/*</include>
 					</bundles>
 				</configuration>
 				<executions>


### PR DESCRIPTION
Use bnd-indexer-plugin to create a local-index that can be used to feed the "Browse Repos" list of the BndTools bndrun editor. It is required to build the product fist to generate the index.xml in
the target folder inside the project structure